### PR TITLE
fix broken link on mobile for g+ page

### DIFF
--- a/freemobilenetstat/src/main/assets/CHANGELOG.html
+++ b/freemobilenetstat/src/main/assets/CHANGELOG.html
@@ -52,8 +52,7 @@
             <div id="googleplus">
                 <p>
                     Retrouvez toute l'actualité de <strong>Free&nbsp;Mobile&nbsp;Netstat</strong>
-                    sur <a
-                        href="https://plus.google.com/u/0/b/110276547074435126555/">Google+</a>.
+                    sur <a href="https://plus.google.com/+FreemobilenetstatAppspot">Google+</a>.
                 </p>
             </div>
             <h1>Nouveautés</h1>


### PR DESCRIPTION
Le lien présent était celui réservé à l'administrateur de la page.
Sur web desktop, Google+ semble le détecter et rediriger les visiteurs vers la page Google+ publique, mais sur mobile (testé sur Chrome Beta sur Lollipop), il ne redirige pas et retourne une erreur 404. D'où ma correction afin d'utiliser l'adresse de référence : https://plus.google.com/+FreemobilenetstatAppspot

Merci pour cette application utile et surtout open-source ! :+1: 